### PR TITLE
Detect devices for existing brands: Infinix, Oukitel, Inoi, Wileyfox,Teclast, Iris, Umax, Sencor, Meizu, Huawei, Blu, MyPhone, Hisense, ZTE, Vivo 

### DIFF
--- a/regexes/device-index-hash.yml
+++ b/regexes/device-index-hash.yml
@@ -21566,6 +21566,8 @@ h30-t10:
   - Huawei
 hw-h30-c00:
   - Huawei
+zh-cn) release/07.10.2014 browser/wap2.0 (:
+  - Huawei
 honor h30-l01m:
   - Huawei
 honor h30-l02:
@@ -28849,6 +28851,8 @@ pmid71c:
   - Polaroid
 t-i708d:
   - Panacom
+build/ics.polypad.7208hd.dualcore.20121101:
+  - PolyPad
 poly pad_8208hd:
   - PolyPad
 pgps7797:

--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -87,14 +87,14 @@ HTC:
   device: 'smartphone'
   models:
     # explicit smartphone models
-    - regex: '2PZC5(?:[);/ ]|$)'
-      model: 'U11'
     - regex: '2PZF1(?:[);/ ]|$)'
       model: 'U Ultra'
     - regex: 'HTC[_ ](?:U-2u|U Play|2PZM3)(?:[);/ ]|$)'
       model: 'U Play'
     - regex: '(?:U11 plus|(?:HTC_)?2Q4D100)(?:[);/ ]|$)'
       model: 'U11 Plus'
+    - regex: 'HTC (?:U12\+|2Q55100)(?:[);/ ]|$)'
+      model: 'U12 Plus'
     - regex: 'U11 life(?:[);/ ]|$)'
       model: 'U11 Life'
     - regex: 'XV6975(?:[);/ ]|$)'
@@ -103,7 +103,7 @@ HTC:
       model: 'Evo 3G'
     - regex: 'PC36100(?:[);/ ]|$)'
       model: 'Evo 4G'
-    - regex: '(?:HTV33|601HT)(?:[);/ ]|$)'
+    - regex: '(?:HTC[_ ])?(?:HTV33|601HT|2PZC100|2PZC5|U-3u)(?:[);/ ]|$)'
       model: 'U11'
     - regex: '(?:801e|802[wdt])'
       model: 'One'
@@ -179,7 +179,7 @@ HTC:
       model: 'Desire 601'
     - regex: 'HTC_?D620h(?:[);/ ]|$)'
       model: 'Desire 620'
-    - regex: 'HTC_D626ph(?:[);/ ]|$)'
+    - regex: 'HTC[_ ]?(?:D626ph|D200LVWPP)(?:[);/ ]|$)'
       model: 'Desire 626'
     - regex: 'HTC_?(?:0P9C2|D816[xd]?)(?:[);/ ]|$)'
       model: 'Desire 816'
@@ -2864,7 +2864,7 @@ Bitel:
 
 # Blu
 Blu:
-  regex: 'BLU[ _]|(?:blu|Dash)[ _]([^/;)]+)(?: Build|[;)])|(?:Studio[ _](5.0K|5.5|View XL|Mega|C 8\+8|[CGM][ _]HD|[CGX]|SELFIE|Selfie LTE|Touch|M5 Plus|J[1258]|X8 HD)|Advance (4.0 ?[LM]|5.[02](?: HD)?|A4|L[45])|ENERGY (DIAMOND|XL)|Energy X 2|LIFE XL|B110DL|Dash (?:X[2L]|L3)|PURE (?:X[LR]|MINI|View)|Life One X2|G90(?: PRO)?|Grand M3|GRAND (?:5.5 HD|XL LTE)|R1 (?:HD|PLUS)|R2 (?:LTE|Plus)|Tank Xtreme [45].0|Tank Xtreme Pro|Touchbook M7 Pro|DASH X PLUS|C[456] 2019|BOLD N1|B130DL|Vivo (?:5 Mini|One Plus|5R|XL2)|C5L 2020)(?:[);/ ]|$)'
+  regex: 'BLU[ _]|(?:blu|Dash)[ _]([^/;)]+)(?: Build|[;)])|(?:Studio[ _](5.0K|5.5|View XL|Mega|C 8\+8|[CGM][ _]HD|[CGX]|SELFIE|Selfie LTE|Touch|M5 Plus|J[1258]|X8 HD)|Advance (4.0 ?[LM]|5.[02](?: HD)?|A4|L[45])|ENERGY (DIAMOND|XL)|Energy X 2|LIFE XL|B110DL|Dash (?:X[2L]|L3)|PURE (?:X[LR]|MINI|View)|Life One X2|G90(?: PRO)?|Grand M3|GRAND (?:5.5 HD|XL LTE)|R1 (?:HD|PLUS)|R2 (?:LTE|Plus)|Tank Xtreme [45].0|Tank Xtreme Pro|Touchbook M7 Pro|DASH X PLUS|C[456] 2019|BOLD N1|B130DL|Vivo (?:5 Mini|One Plus|5R|XL2|8L)|C5L 2020)(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     - regex: 'Advance (4.0 ?[LM]|4.0|5.[02](?: HD)?|A4|L[54])'
@@ -2961,7 +2961,7 @@ Blu:
       model: 'Vivo 5 Mini'
     - regex: '(?:BLU[_ ])?Vivo One Plus'
       model: 'Vivo One Plus'
-    - regex: '(?:BLU[_ ])?Vivo (5R|XL2)'
+    - regex: '(?:BLU[_ ])?Vivo (5R|XL2|8L)'
       model: 'Vivo $1'
 
     - regex: 'Touchbook M7 Pro'
@@ -3201,12 +3201,14 @@ Vivo:
       model: 'U20'
     - regex: 'vivo 1805(?:[);/ ]|$)'
       model: 'Nex'
-    - regex: 'V1923A(?:[);/ ]|$)'
+    - regex: '(?:vivo 1912|V1923A)(?:[);/ ]|$)'
       model: 'Nex 3'
     - regex: 'V1924A(?:[);/ ]|$)'
       model: 'Nex 3 5G'
     - regex: 'V1950A(?:[);/ ]|$)'
       model: 'Nex 3S'
+    - regex: 'vivo NEX S(?:[);/ ]|$)'
+      model: 'Nex S'
     - regex: 'V1821[AT](?:[);/ ]|$)'
       model: 'Nex Dual Display'
     - regex: 'Vivo ONE(?:[);/ ]|$)'
@@ -3423,7 +3425,7 @@ Vivo:
       model: 'Z1x'
     - regex: 'V1813B[AT](?:[);/ ]|$)'
       model: 'Z3'
-    - regex: 'V1730GA(?:[);/ ]|$)'
+    - regex: '(?:vivo Z3x|V1730GA)(?:[);/ ]|$)'
       model: 'Z3x'
     - regex: 'V1921A(?:[);/ ]|$)'
       model: 'Z5'
@@ -6068,7 +6070,7 @@ Evolveo:
     - regex: 'Smart TV ([^;/]*) Build'
       device: 'tv'
       model: 'Smart TV $1'
-    - regex: 'EVOLVEO StrongPhone G([248])'
+    - regex: 'EVOLVEO StrongPhone G([2478])'
       model: 'StrongPhone G$1'
     - regex: '(?:EVOLVEO[ _])?StrongPhone[ _]?Q([679])(_LTE)?'
       model: 'StrongPhone Q$1$2'
@@ -7279,7 +7281,7 @@ Huawei:
       model: 'Mate 40 Pro'
     - regex: 'NOP-AN00(?:[);/ ]|$)'
       model: 'Mate 40 Pro+'
-    - regex: 'NXT-(?:AL10|L29)(?:[);/ ]|$)'
+    - regex: 'NXT-(?:AL10|L[02]9)(?:[);/ ]|$)'
       model: 'Mate 8'
     - regex: 'MHA-(?:L[02]9|[AT]L00)(?:[);/ ]|$)'
       model: 'Mate 9'
@@ -7409,6 +7411,8 @@ Huawei:
       model: 'P9 Lite Smart'
     - regex: 'VIE-(?:AL10|L[02]9)(?:[);/ ]|$)'
       model: 'P9 Plus'
+    - regex: 'MLA-TL[01]0(?:[);/ ]|$)'
+      model: 'G9 Plus'
     - regex: 'ATH-UL0[16](?:[);/ ]|$)'
       model: 'ShotX'
     - regex: 'U(8230|8661|8667)(?:[);/ ]|$)'
@@ -7497,6 +7501,8 @@ Huawei:
       model: 'Y9a'
     - regex: '302HW(?:[);/ ]|$)'
       model: 'Stream S'
+    - regex: 'NMO-L31(?:[);/ ]|$)'
+      model: 'GT3'
 
     - regex: 'HWT31(?:[);/ ]|$)'
       model: 'Qua Tab 02 10.1"'
@@ -8177,6 +8183,12 @@ Infinix:
       model: 'Zero 5 Pro'
     - regex: 'Infinix[ _-]X620'
       model: 'Zero 6'
+    - regex: 'Infinix[ _-]X687B'
+      device: 'phablet'
+      model: 'Zero 8i'
+    - regex: 'Infinix[ _-]X687'
+      device: 'phablet'
+      model: 'Zero 8'
 
     - regex: 'Infinix[ _-]X507'
       model: 'Hot'
@@ -8202,26 +8214,41 @@ Infinix:
       model: 'Hot 6 Pro'
     - regex: 'Infinix[ _-]X624'
       model: 'Hot 7'
+    - regex: 'Infinix[ _-]X625'
+      model: 'Hot 7 Pro'
     - regex: 'Infinix[ _-]X650'
       model: 'Hot 8'
     - regex: 'Infinix[ _-]X655'
       model: 'Hot 9'
     - regex: 'Infinix[ _-]X680'
       model: 'Hot 9 Play'
+    - regex: 'Infinix[ _-]X688'
+      model: 'Hot 10 Play'
+    - regex: 'Infinix[ _-]X682[BC]'
+      model: 'Hot 10'
     - regex: 'Infinix[ _-]X573B?'
       model: 'Hot S3'
 
+
+    - regex: 'Infinix[ _-]X612'
+      model: 'Smart HD (2021)'
     - regex: 'Infinix[ _-]X5010'
       model: 'Smart'
     - regex: 'Infinix[ _-]X5515F'
       model: 'Smart 2'
-    - regex: 'Infinix[ _-]X627V'
+    - regex: 'Infinix[ _-]X609'
+      model: 'Smart 2 HD'
+    - regex: 'Infinix[ _-]X627'
       model: 'Smart 3 Plus'
     - regex: 'Infinix[ _-]X5514D'
       model: 'Smart 2 Pro'
     - regex: 'Infinix[ _-]X653'
       model: 'Smart 4'
+    - regex: 'Infinix[ _-]X657'
+      model: 'Smart 5'
 
+    - regex: 'Infinix[ _-]X652B'
+      model: 'S5 Lite'
     - regex: 'Infinix[ _-]X626'
       model: 'S4'
     - regex: 'Infinix[ _-]X652'
@@ -8255,6 +8282,15 @@ Infinix:
       device: 'phablet'
     - regex: 'Infinix[ _-]X656'
       model: 'Note 7 Lite'
+      device: 'phablet'
+    - regex: 'Infinix[ _-]X692'
+      model: 'Note 8'
+      device: 'phablet'
+    - regex: 'Infinix[ _-]X683'
+      model: 'Note 8i'
+      device: 'phablet'
+    - regex: 'Infinix[ _-]X695'
+      model: 'Note 10 Pro'
       device: 'phablet'
 
     - regex: 'Infinix HOT ([a-z]?[1-6])( (?:Lite|Plus|Pro))?'
@@ -9029,7 +9065,7 @@ Kyocera:
 
 # Krüger&Matz (Kruger&Matz)
 Krüger&Matz:
-  regex: 'Kruger[ _&]Matz|KrugerMatz[ _]|FLOW ?5PLUS|FLOW_5|FLOW7|FLOW6(?:S|Lite)|DRIVE9|DRIVE[_ ]6S?|MOVE8mini|MOVE_|LIVE_6plus|LIVE 5 PLUS|LIVE4_KM043[89]|LIVE 7S|KM(?:106[67]|1065G|0701_1|0702|0805_1)'
+  regex: 'Kruger[ _&]Matz|KrugerMatz[ _]|FLOW ?5PLUS|FLOW_5|FLOW7|FLOW6(?:S|Lite)|DRIVE9|DRIVE[_ ]6S?|MOVE8mini|MOVE_|LIVE_6plus|LIVE 5 PLUS|LIVE4_KM043[89]|LIVE 7S|Flow 7S|KM(?:106[67]|1065G|0701_1|0702|0805_1)'
   device: 'smartphone'
   models:
     - regex: 'MOVE8mini'
@@ -10908,7 +10944,7 @@ Meizu:
       model: 'M1 Metal'
     - regex: 'M1813(?:[);/ ]|$)'
       model: 'M8'
-    - regex: 'M1816(?:[);/ ]|$)'
+    - regex: '(?:M1816|M8 lite)(?:[);/ ]|$)'
       model: 'M8 Lite'
 
     - regex: 'PRO 7-[HS](?:[);/ ]|$)'
@@ -10937,8 +10973,8 @@ Meizu:
       model: '16th'
     - regex: 'MZ-16 X(?:[);/ ]|$)'
       model: '16X'
-    - regex: 'meizu 17 Pro(?:[);/ ]|$)'
-      model: '17 Pro'
+    - regex: 'meizu (17|C9) Pro(?:[);/ ]|$)'
+      model: '$1 Pro'
     - regex: 'Meizu[_ ]note([89])(?:[);/ ]|$)'
       device: 'phablet'
       model: 'Note $1'
@@ -11593,7 +11629,7 @@ MyPhone:
       model: 'Pocket 2'
     - regex: 'myA17(?:[);/ ]|$)'
       model: 'myA17'
-    - regex: '(?:myPhone_)?Fun_(8|18x9)'
+    - regex: '(?:myPhone_)?Fun_?([48]|18x9)'
       model: 'FUN $1'
     - regex: 'MyPhoneMY27'
       model: 'my27'
@@ -11613,6 +11649,8 @@ MyPhone:
       model: 'Prime 3 Lite'
     - regex: 'Brown 1(?:[);/ ]|$)' # ARK Brown 1
       model: 'Brown 1'
+    - regex: 'myPhone[_ ]Pocket[_ ]Pro'
+      model: 'Pocket Pro'
 
     # general detections
     - regex: 'MyPhone[ _]([^;/)]+)( Build|\))'
@@ -12870,7 +12908,7 @@ Orange:
 
 # Oukitel
 Oukitel:
-  regex: 'OUKITEL|(?:(?:C15|C16|K10000|K[46]000)(?:[ _]Pro)|K4000Pro|U15 Pro|U16 Max|U7 Max|U7 Plus|U11[_ ]Plus|U20_Plus|OK6000 Plus|WP5000|WP[58] Pro|K[46]000[ _](?:Plus|Lite)|Y4800|K10000|K[4-8]000| WP(?:[5-7]|12))(?:[);/ ]|$)'
+  regex: 'OUKITEL|(?:(?:C15|C16|K10000|K[46]000)(?:[ _]Pro)|K4000Pro|U15 Pro|K15_Plus|U16 Max|U7 Max|U7 Plus|U11[_ ]Plus|U20_Plus|OK6000 Plus|WP5000|WP[58] Pro|K[46]000[ _](?:Plus|Lite)|Y4800|K10000|K[4-8]000| WP(?:[5-7]|12))(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     - regex: '(C15|C16|K10000|K[46]000|WP[258]|U15)[ _]?Pro(?:[);/ ]|$)'
@@ -12879,7 +12917,7 @@ Oukitel:
       model: 'K$1'
     - regex: '(K10000|U16|U7)[ _]Max(?:[);/ ]|$)'
       model: '$1 Max'
-    - regex: '(U20|K[46]000|U7|U11|OK6000)[_ ]?Plus(?:[);/ ]|$)'
+    - regex: '(U20|K[46]000|U7|U11|OK6000|K15)[_ ]?Plus(?:[);/ ]|$)'
       model: '$1 Plus'
     - regex: '(K4000)[_ ]Lite(?:[);/ ]|$)'
       model: '$1 Lite'
@@ -14739,9 +14777,9 @@ Selfix:
     - regex: 'VOYAGER-V45'
       model: 'Voyager V45'
 
-# Sencor
+# Sencor (sencor.cz or sencor.com)
 Sencor:
-  regex: 'Sencor|ELEMENT[ _]?(?:7|8|9\.7|10[ _]1)(?:[ _]?V[23])?(?:[);/ ]|$)|ELEMENT[ _]?(?:P[0-9]+|10.1 Q001)(?:[);/ ]|$)'
+  regex: 'Sencor|(?:ELEMENT[ _]?(?:(?:7|8|9\.7|10[ _]1)(?:[ _]?V[23])?|P[0-9]+|10.1 Q001)|10_1Q205)(?:[);/ ]|$)'
   device: 'tablet'
   models:
     # explicit tablet models
@@ -14769,6 +14807,8 @@ Sencor:
       model: 'Element 10.1'
     - regex: '(?:SENCOR[ _])?(7Q105)(?:[);/ ]|$)'
       model: '$1'
+    - regex: '(10)_(1Q205)(?:[);/ ]|$)'
+      model: '$1.$2'
 
     - regex: '(?:SENCOR[ _])?ELEMENT[ _]?P([0-9]+)'
       model: 'Element P$1'
@@ -16128,13 +16168,15 @@ T-Mobile:
 
 # Teclast (teclast.com)
 Teclast:
-  regex: 'Teclast|TLA002|TLA016|X98 Air III|M20_4G|X98 Air II\(HG5N\)|Tbook|X80 Power\(B2N4\)|(?:T30|P80[XH]|P20HD|P10[_ ]HD|M40)_(?:ROW|EEA)|T10\(E3C6\)|P10S\(N4H5\)|98\(M1E[45789]\)|98\(M3E3\)'
+  regex: 'Teclast|TLA002|TLA016|X98 Air III|M20_4G|X98 Air II\(HG5N\)|Tbook|X80 Power\(B2N4\)|(?:T30|P80[XH]|P20HD|P10[_ ]HD|M40)_(?:ROW|EEA)|T10\(E3C6\)|P10S\(N4H5\)|98\(M1E[45789]\)|98\(M3E3\)|X10 \(M1D3\)'
   device: 'tablet'
   models:
     - regex: 'Tbook[_ -]([^;/]+) Build'
       model: 'Tbook $1'
     - regex: 'T10\(E3C6\)'
       model: 'T10'
+    - regex: 'X10 \(M1D3\)'
+      model: 'X10'
     - regex: 'P10S\(N4H5\)'
       model: 'P10S'
     - regex: 'P20HD_(?:ROW|EEA)'
@@ -17760,11 +17802,13 @@ Weimei:
 
 # Wileyfox
 Wileyfox:
-  regex: '(?:Wileyfox [^/]+)|Swift 2(?:[);/ ]|$)'
+  regex: 'Wileyfox|Swift 2(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     - regex: 'Wileyfox Spark \+'
       model: 'Spark +'
+    - regex: 'Wileyfox; Pro'
+      model: 'Pro'
     - regex: 'Wileyfox Spark X'
       model: 'Spark X'
     - regex: 'Wileyfox (Spark|Swift)'
@@ -19170,6 +19214,8 @@ ZTE:
       model: 'Blade A6'
     - regex: 'BLADE (?:A6 MAX|A0605)(?:[);/ ]|$)'
       model: 'Blade A6 Max'
+    - regex: 'A0622(?:[);/ ]|$)'
+      model: 'Blade A6 Lite'
     - regex: 'Blade S6 Plus(?:[);/ ]|$)'
       model: 'Blade S6 Plus'
     - regex: 'Blade S6(?:[);/ ]|$)'
@@ -19200,6 +19246,8 @@ ZTE:
       model: 'Blade V8Q'
     - regex: 'Blade V8 SE(?:[);/ ]|$)'
       model: 'Blade V8 SE'
+    - regex: 'BLADE V0920'
+      model: 'Blade V9 Vita'
     - regex: 'Blade V(9|10) Vita(?:[);/ ]|$)'
       model: 'Blade V$1 Vita'
     - regex: 'Blade V([89]|10)(?:[);/ ]|$)'
@@ -19523,8 +19571,8 @@ Inoi:
   regex: 'INOI'
   device: 'smartphone'
   models:
-    - regex: 'INOI 2 Lite 2019'
-      model: '2 Lite (2019)'
+    - regex: 'INOI (2|5) Lite (2019|2021)'
+      model: '$1 Lite ($2)'
     - regex: 'INOI[_ ]([13])[_ ]LITE'
       model: '$1 Lite'
     - regex: 'INOI ([257]) (2019|202[01])(?:[);/ ]|$)'
@@ -19850,9 +19898,9 @@ Qumo:
       device: 'smartphone'
       model: 'Quest $1'
 
-# Umax
+# Umax (umax.cz)
 Umax:
-  regex: 'VisionBook[ _]|([78]Qa_3G|VB_10Q_Plus)(?:[);/ ]|$)'
+  regex: 'VisionBook[ _]|([78]Qa_3G|VB_10Q_Plus|10A_LTE_eea)(?:[);/ ]|$)'
   device: 'tablet'
   models:
     - regex: '(VisionBook[ _](?:10Qi|7Q[i]?|8Q[ei]?|P70|8Qi_3G)(?:[ _](?:[34]G|Plus|LTE))?)(?:[);/ ]|$)'
@@ -19861,6 +19909,8 @@ Umax:
       model: 'VisionBook $1Qa 3G'
     - regex: 'VisionBook_10Q_LTE(?:[);/ ]|$)'
       model: 'VisionBook 10Q LTE'
+    - regex: '10A_LTE_eea(?:[);/ ]|$)'
+      model: 'VisionBook 10A LTE'
     - regex: 'VB_10Q_Plus(?:[);/ ]|$)'
       model: 'VisionBook 10Q Plus'
     - regex: 'VisionBook_P50Plus_LTE(?:[);/ ]|$)'
@@ -21821,7 +21871,7 @@ Pixela:
 
 # Iris
 Iris:
-  regex: '(?:Vox[_ ](?:[45]S|Alpha|POP|STEEL Plus|Energy|FORTIS|VERO)|IS2_?Plus|IS2S|Next_P_PRO|IRS002-16)(?:[);/ ]|$)'
+  regex: '(?:Vox[_ ](?:[45]S|Alpha|POP|STEEL Plus|Energy|FORTIS|VERO)|IS2_?Plus|IS2S|Next_P_PRO|IRS002-16|X1 mini)(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     - regex: 'Vox[_ ]([45])S'
@@ -21850,6 +21900,8 @@ Iris:
       model: 'I-S6'
     - regex: 'IS2S'
       model: 'IS2S'
+    - regex: 'X1 mini'
+      model: 'X1 Mini'
 
 # Fonos
 Fonos:

--- a/tests/fixtures/devices/phablet.yml
+++ b/tests/fixtures/devices/phablet.yml
@@ -6734,3 +6734,129 @@
     model: Redmi Note 5
   os_family: Android
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; arm_64; Android 7.1.2; M6 Note) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.216 YaBrowser/21.5.5.110.00 SA/3 Mobile Safari/537.36
+  os:
+    name: Android
+    version: 7.1.2
+    platform: ARM
+  client:
+    type: browser
+    name: Yandex Browser
+    version: 21.5.5.110.00
+    engine: Blink
+    engine_version: ""
+  device:
+    type: phablet
+    brand: Meizu
+    model: M6 Note
+  os_family: Android
+  browser_family: Unknown
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X692) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.115 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.115
+    engine: Blink
+    engine_version: ""
+  device:
+    type: phablet
+    brand: Infinix
+    model: Note 8
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X690B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.101
+    engine: Blink
+    engine_version: ""
+  device:
+    type: phablet
+    brand: Infinix
+    model: Note 7
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X687B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.120
+    engine: Blink
+    engine_version: ""
+  device:
+    type: phablet
+    brand: Infinix
+    model: Zero 8i
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X687) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.88 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.88
+    engine: Blink
+    engine_version: ""
+  device:
+    type: phablet
+    brand: Infinix
+    model: Zero 8
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X683) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.120
+    engine: Blink
+    engine_version: ""
+  device:
+    type: phablet
+    brand: Infinix
+    model: Note 8i
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; Infinix X695C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.105 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.105
+    engine: Blink
+    engine_version: ""
+  device:
+    type: phablet
+    brand: Infinix
+    model: Note 10 Pro
+  os_family: Android
+  browser_family: Chrome

--- a/tests/fixtures/devices/smartphone-25.yml
+++ b/tests/fixtures/devices/smartphone-25.yml
@@ -2897,3 +2897,957 @@
     model: One X10
   os_family: Android
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; Wileyfox; Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Mobile Safari/537.36 Edge/15.15254
+  os:
+    name: Windows Phone
+    version: "10.0"
+    platform: ""
+  client:
+    type: browser
+    name: Microsoft Edge
+    version: "15.15254"
+    engine: Edge
+    engine_version: "15.15254"
+  device:
+    type: smartphone
+    brand: Wileyfox
+    model: Pro
+  os_family: Windows Mobile
+  browser_family: Internet Explorer
+-
+  user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X1 mini) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
+  os:
+    name: Android
+    version: 4.4.2
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 79.0.3945.116
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Iris
+    model: X1 Mini
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; arm_64; Android 10; vivo 1912) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.216 YaBrowser/21.5.4.119.00 SA/3 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ARM
+  client:
+    type: browser
+    name: Yandex Browser
+    version: 21.5.4.119.00
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Vivo
+    model: Nex 3
+  os_family: Android
+  browser_family: Unknown
+-
+  user_agent: Mozilla/5.0 (Linux; arm_64; Android 10; vivo NEX S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.216 YaBrowser/21.5.2.110.00 SA/3 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ARM
+  client:
+    type: browser
+    name: Yandex Browser
+    version: 21.5.2.110.00
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Vivo
+    model: Nex S
+  os_family: Android
+  browser_family: Unknown
+-
+  user_agent: Mozilla/5.0 (Linux; arm_64; Android 10; vivo Z3x) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.216 YaBrowser/21.5.5.110.00 SA/3 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ARM
+  client:
+    type: browser
+    name: Yandex Browser
+    version: 21.5.5.110.00
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Vivo
+    model: Z3x
+  os_family: Android
+  browser_family: Unknown
+-
+  user_agent: Mozilla/5.0 (Linux; arm_64; Android 7.0; HUAWEI NMO-L31) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 YaApp_Android/21.50.1 YaSearchBrowser/21.50.1 BroPP/1.0 SA/3 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "7.0"
+    platform: ARM
+  client:
+    type: browser
+    name: Yandex Browser
+    version: 21.50.1
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Huawei
+    model: GT3
+  os_family: Android
+  browser_family: Unknown
+-
+  user_agent: Mozilla/5.0 (Linux; arm_64; Android 7.1.1; ZTE A0622) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.216 YaBrowser/21.5.6.56.00 SA/3 Mobile Safari/537.36
+  os:
+    name: Android
+    version: 7.1.1
+    platform: ARM
+  client:
+    type: browser
+    name: Yandex Browser
+    version: 21.5.6.56.00
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: ZTE
+    model: Blade A6 Lite
+  os_family: Android
+  browser_family: Unknown
+-
+  user_agent: Mozilla/5.0 (Linux; arm_64; Android 7.0; Vivo 8L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.216 YaApp_Android/21.51.1 YaSearchBrowser/21.51.1 BroPP/1.0 (beta) SA/3 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "7.0"
+    platform: ARM
+  client:
+    type: browser
+    name: Yandex Browser
+    version: 21.51.1
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Blu
+    model: Vivo 8L
+  os_family: Android
+  browser_family: Unknown
+-
+  user_agent: Mozilla/5.0 (Linux; arm_64; Android 8.1.0; ZTE BLADE V0920) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 YaBrowser/21.5.0.350.00 SA/3 Mobile Safari/537.36
+  os:
+    name: Android
+    version: 8.1.0
+    platform: ARM
+  client:
+    type: browser
+    name: Yandex Browser
+    version: 21.5.0.350.00
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: ZTE
+    model: Blade V9 Vita
+  os_family: Android
+  browser_family: Unknown
+-
+  user_agent: Mozilla/5.0 (Linux; arm_64; Android 9; Hisense Rock 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 YaApp_Android/21.50.1 YaSearchBrowser/21.50.1 BroPP/1.0 SA/3 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ARM
+  client:
+    type: browser
+    name: Yandex Browser
+    version: 21.50.1
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Hisense
+    model: Rock 5
+  os_family: Android
+  browser_family: Unknown
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 9; myPhone_Pocket_Pro Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/90.0.4430.210 Mobile Safari/537.36 OPR/56.0.2254.57357
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Opera Mobile
+    version: 56.0.2254.57357
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: MyPhone
+    model: Pocket Pro
+  os_family: Android
+  browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; meizu C9 pro Build/OPM2.171019.012; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/91.0.4472.88 Mobile Safari/537.36 OPR/56.1.2254.57583
+  os:
+    name: Android
+    version: 8.1.0
+    platform: ""
+  client:
+    type: browser
+    name: Opera Mobile
+    version: 56.1.2254.57583
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Meizu
+    model: C9 Pro
+  os_family: Android
+  browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; meizu M8 lite Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/91.0.4472.77 Mobile Safari/537.36 OPR/27.0.2254.118423
+  os:
+    name: Android
+    version: 8.1.0
+    platform: ""
+  client:
+    type: browser
+    name: Opera Mobile
+    version: 27.0.2254.118423
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Meizu
+    model: M8 Lite
+  os_family: Android
+  browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI MLA-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "7.0"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.101
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Huawei
+    model: G9 Plus
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI MLA-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.210 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "7.0"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 90.0.4430.210
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Huawei
+    model: G9 Plus
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI NXT-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "7.0"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 90.0.4430.91
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Huawei
+    model: Mate 8
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.0; EVA-L19) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.40 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "7.0"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.40
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Huawei
+    model: P9
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; JSN-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4557.4 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 93.0.4557.4
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Huawei
+    model: Honor 8X
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; INOI 5 Lite 2021) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.70 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.70
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Inoi
+    model: 5 Lite (2021)
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; INOI 2 Lite 2021) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.88 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.88
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Inoi
+    model: 2 Lite (2021)
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; INOI 2 2021) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.88 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.88
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Inoi
+    model: 2 (2021)
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; K15_Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.115 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.115
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Oukitel
+    model: K15 Plus
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X612B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 90.0.4430.91
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Smart HD (2021)
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X657) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 90.0.4430.91
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Smart 5
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X657B Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.88 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.88
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Smart 5
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X657C Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.120
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Smart 5
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X680F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.82 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 90.0.4430.82
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Hot 9 Play
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X680) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 90.0.4430.91
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Hot 9 Play
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X688C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.115 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.115
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Hot 10 Play
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X688B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.88 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.88
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Hot 10 Play
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X682B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.88 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.88
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Hot 10
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X682C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.88 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.88
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Hot 10
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X660C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.210 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 90.0.4430.210
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: S5 Pro
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; Infinix X650 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/91.0.4472.120 Mobile Safari/537.36 OPR/55.0.2254.56857
+  os:
+    name: Android
+    version: 8.1.0
+    platform: ""
+  client:
+    type: browser
+    name: Opera Mobile
+    version: 55.0.2254.56857
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Hot 8
+  os_family: Android
+  browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; Infinix X609 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/90.0.4430.210 Mobile Safari/537.36 OPR/55.0.2254.56695
+  os:
+    name: Android
+    version: 8.1.0
+    platform: ""
+  client:
+    type: browser
+    name: Opera Mobile
+    version: 55.0.2254.56695
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Smart 2 HD
+  os_family: Android
+  browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; Infinix X653C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.77
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Smart 4
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; Infinix X627 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/90.0.4430.210 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Webview
+    version: 90.0.4430.210
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Smart 3 Plus
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; Infinix X625C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.82 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 90.0.4430.82
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Hot 7 Pro
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; Infinix X650B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 90.0.4430.91
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Hot 8
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; Infinix X650D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.82 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 90.0.4430.82
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Hot 8
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; Infinix X652B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.101
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: S5 Lite
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; INE-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.164
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Huawei
+    model: Nova 3i
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.0; Infinix X559) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.82 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "7.0"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 90.0.4430.82
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Infinix
+    model: Hot 5 Lite
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 5.1; HUAWEI TIT-L01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.88 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "5.1"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.88
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Huawei
+    model: Y6 Pro
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 5.1; HTCD200LVWPP) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.88 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "5.1"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.88
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: HTC
+    model: Desire 626
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 5.1; myPhone FUN4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.91 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "5.1"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 90.0.4430.91
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: MyPhone
+    model: FUN 4
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; ALP-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.164
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Huawei
+    model: Mate 10
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; EVOLVEO StrongPhone G7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.164
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Evolveo
+    model: StrongPhone G7
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; Flow 7S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.88 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.88
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: 'Krüger&Matz'
+    model: FLOW 7S
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; HTC U12+) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.105 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.105
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: HTC
+    model: U12 Plus
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; HTC 2PZC100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.120
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: HTC
+    model: U11
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; HTC 2Q55100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.88 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.88
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: HTC
+    model: U12 Plus
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; HTC_U-3u) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.88 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.88
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: HTC
+    model: U11
+  os_family: Android
+  browser_family: Chrome

--- a/tests/fixtures/devices/smartphone-6.yml
+++ b/tests/fixtures/devices/smartphone-6.yml
@@ -5872,7 +5872,7 @@
   os_family: Android
   browser_family: Chrome
 - 
-  user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0zh-cn; INE-TL00 Build/HUAWEIINE-TL00) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.1 Mobile Safari/537.36
+  user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-cn; INE-TL00 Build/HUAWEIINE-TL00) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.1 Mobile Safari/537.36
   os:
     name: Android
     version: "8.1.0"


### PR DESCRIPTION
* feat(device) detect brand Teclast model: X10
feat(device) detect brand Iris model: X1 Mini

* feat(device) detect brand Umax model: VisionBook 10A LTE
feat(device) detect brand Sencor model: 10.1Q205

* feat(device) detect brand Meizu models: M6 Note, C9 Pro, M8 Lite
feat(device) detect brand Huawei model: GT3 (NMO-L31)
feat(device) detect brand Blu model: Vivo 8L
feat(device) detect brand Hisense model: Rock 5
feat(device) detect brand MyPhone model: Pocket Pro
feat(device) detect brand ZTE model: Blade A6 Lite (A0622), Blade V9 Vita (V0920)
feat(device) detect brand Vivo models: Nex 3 (1912), Nex S, Z3x

* feat(device) detect brand Infinix models: Note 8 (X692), Note 7 (X690B), Zero 8i (X687B),
 Zero 8 (X687), Note 8i (X683), Note 10 Pro (X695C), Smart HD (2021) (X612B), Smart 5 (X657, X657B, X657C),
 Hot 9 Play (X680F, X680), Hot 10 Play (X688C, X688B), Hot 10 (X682B, X682C), S5 Pro (X660C), Hot 8 (X650),
 Smart 2 HD (X609), Smart 4 (X653C), Smart 3 Plus (X627), Hot 7 Pro (X625C), Hot 8 (X650B, X650D),
 S5 Lite (X652B), Hot 5 Lite (X559)
feat(device) detect brand Huawei models: G9 Plus (MLA-TL10, MLA-TL00), Mate 8 (NXT-L09), P9 (EVA-L19), Honor 8X (JSN-L22),
 Nova 3i (INE-TL00)
feat(device) detect brand Inoi models: 5 Lite (2021), 2 Lite (2021), 2 (2021)
feat(device) detect brand Oukitel model: K15 Plus

* fix: tests

* feat(device) detect brand Huawei models: Y6 Pro (TIT-L01), Mate 10 (ALP-L29)
feat(device) detect brand MyPhone model: FUN 4
feat(device) detect brand Krüger&Matz model: FLOW 7S
feat(device) detect brand Evolveo model: StrongPhone G7
feat(device) detect brand HTC models: Desire 626 (HTCD200LVWPP), U12 Plus (2Q55100), U11 (2PZC100, U-3u)