### PR TITLE
Detect devices for existing brands: A1, Huawei, Crosscall, Samsung, Tecno Mobile, Teclast, Realme, Reeder, Leagoo, OPPO, Sony, Asus, Sharp, Fujitsu, Xiaomi, Motorola

### DIFF
--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -2741,7 +2741,7 @@ Asus:
       model: 'ROG Phone 2'
     - regex: '(?:ASUS_)?(?:I003DD?|ZS661KS)'
       model: 'ROG Phone 3'
-    - regex: '(?:ASUS_)?(?:I005DA|ZS673KS)'
+    - regex: '(?:ASUS_)?(?:I005D[AC]|ZS673KS)'
       model: 'ROG Phone 5'
 
     # desktop detections
@@ -4569,13 +4569,13 @@ Cricket:
 
 # Crosscall
 Crosscall:
-  regex: 'Crosscall|ODYSSEY_Plus|Odyssey S1|Trekker-[MSX][1234]|Action-X3|Core-X3'
+  regex: 'Crosscall|ODYSSEY_Plus|Odyssey S1|Trekker-[MSX][1234]|Action-X3|Core-X[34]'
   device: 'smartphone'
   models:
     - regex: 'Action-X3'
       model: 'Action-X3'
-    - regex: 'Core-X3'
-      model: 'Core-X3'
+    - regex: 'Core-X([34])'
+      model: 'Core-X$1'
     - regex: 'Crosscall ([^;/]+) Build'
       model: '$1'
     - regex: 'ODYSSEY_Plus'
@@ -5433,7 +5433,7 @@ Senseit:
 
 # Sony & Sony Ericsson (combined as they are mixed up)
 Sony:
-  regex: 'Sony(?: ?Ericsson)?|SGP|Xperia|(?:[4-9]0[12])SO|C1[569]0[45]|C2[01]0[45]|C230[45]|C530[236]|C550[23]|C6[56]0[236]|C6616|C68(?:0[26]|[34]3)|C69(?:0[236]|16|43)|D200[45]|D21(?:0[45]|14)|D22(?:0[236]|12|43)|D230[2356]|D240[36]|D25(?:02|33)|D510[236]|D530[36]|D5316|D5322|D5503|D58[03]3|D65(?:0[23]|43|63)|D66[03458]3|D66[14]6|D6708|E(?:20[0345]3|2006|210[45]|2115|2124|230[36]|2312|23[356]3|530[36]|53[3456]3|5506|55[356]3|56[46305][36]|58[02]3|65[35]3|66[0358]3|68[358]3)|I[34]312|I4332|F311[12356]|F331[13]|F321[12356]|F5[13]21|F5122|F813[12]|F833[12]|G312[135]|G311[26]|G322[136]|G3212|G331[123]|G3412|G3416|G342[136]|G823[12]|G834[123]|G8[14]4[12]|G8188|H(?:3113|3123|3133|3213|3223|3311|3321|4113|4133|4213|4233|4311|4331|4413|4433|82[167]6|83[12]4|8416|9436)|(?:WT|LT|SO|ST|SK|MK)[0-9]+[a-z]+[0-9]*(?: Build|\))|X?L39H|XM50[ht]|W960|portalmmm/2\.0 K|S3[69]h|SOG01|SOL2[2346]|SOV3[1-9]|SOV4[0-3]|X10[ia]v?|E1[05][ai]v?|MT[0-9]{2}[a-z]? Build|SO-0(?:[12]C|[345]D|[234]E|[1-5]F|[1-5]G|[1-4]H|[1-4]J|[1-5]K|1M|[1-3]L)|R800[aix]|J3173|J82[17]0|J9110|J92[16]0|J81[17]0|I[34]113|I3[12]23|I42[19]3|H9493|H8296|H8166|H4493|G2299|LiveWithWalkman|BRAVIA|SGP771|E3 Dual|A[01]01SO|I4193|E6508|SOT31|SO-[45]1A|SO-52A|XQ-A[DT]51|XQ-A[TU]42|XQ-AS[67]2|XQ-A[TSU]52|SOL25|SOG02|A002SO|NW-(A100|Z1000)Series|J3273|NSZ-GS7'
+  regex: 'Sony(?: ?Ericsson)?|SGP|Xperia|(?:[4-9]0[12])SO|C1[569]0[45]|C2[01]0[45]|C230[45]|C530[236]|C550[23]|C6[56]0[236]|C6616|C68(?:0[26]|[34]3)|C69(?:0[236]|16|43)|D200[45]|D21(?:0[45]|14)|D22(?:0[236]|12|43)|D230[2356]|D240[36]|D25(?:02|33)|D510[236]|D530[36]|D5316|D5322|D5503|D58[03]3|D65(?:0[23]|43|63)|D66[03458]3|D66[14]6|D6708|E(?:20[0345]3|2006|210[45]|2115|2124|230[36]|2312|23[356]3|530[36]|53[3456]3|5506|55[356]3|56[46305][36]|58[02]3|65[35]3|66[0358]3|68[358]3)|I[34]312|I4332|F311[12356]|F331[13]|F321[12356]|F5[13]21|F5122|F813[12]|F833[12]|G312[135]|G311[26]|G322[136]|G3212|G331[123]|G3412|G3416|G342[136]|G823[12]|G834[123]|G8[14]4[12]|G8188|H(?:3113|3123|3133|3213|3223|3311|3321|4113|4133|4213|4233|4311|4331|4413|4433|82[167]6|83[12]4|8416|9436)|(?:WT|LT|SO|ST|SK|MK)[0-9]+[a-z]+[0-9]*(?: Build|\))|X?L39H|XM50[ht]|W960|portalmmm/2\.0 K|S3[69]h|SOG0[1-4]|SOL2[2346]|SOV3[1-9]|SOV4[0-3]|X10[ia]v?|E1[05][ai]v?|MT[0-9]{2}[a-z]? Build|SO-0(?:[12]C|[345]D|[234]E|[1-5]F|[1-5]G|[1-4]H|[1-4]J|[1-5]K|1M|[1-3]L)|R800[aix]|J3173|J82[17]0|J9110|J92[16]0|J81[17]0|I[34]113|I3[12]23|I42[19]3|H9493|H8296|H8166|H4493|G2299|LiveWithWalkman|BRAVIA|SGP771|E3 Dual|A[01]01SO|A102SO|I4193|E6508|SOT31|SO-[45]1[AB]|SO-52[AB]|XQ-A[DT]51|XQ-A[TU]42|XQ-AS[467]2|XQ-A[TSU]52|SOL25|A002SO|NW-(A100|Z1000)Series|J3273|NSZ-GS7'
   device: 'smartphone'
   models:
     # SONY ERICSSON: explicit smartphone models
@@ -5573,9 +5573,11 @@ Sony:
       model: 'Xperia 10'
     - regex: '(?:Sony(?:Ericsson)?)?J3173(?:[);/ ]|$)'
       model: 'Xperia Ace'
+    - regex: 'SO-41B(?:[);/ ]|$)'
+      model: 'Xperia Ace II'
     - regex: '(?:A001SO|XQ-A[TU]52|XQ-AU42|SO-41A|SOV43)(?:[);/ ]|$)'
       model: 'Xperia 10 II'
-    - regex: 'A101SO(?:[);/ ]|$)'
+    - regex: '(?:A10[12]SO|SO-52B|SOG04)(?:[);/ ]|$)'
       model: 'Xperia 10 III'
     - regex: '(?:Sony(?:Ericsson)?)?I(?:42[19]3|3223)'
       model: 'Xperia 10 Plus'
@@ -5583,8 +5585,10 @@ Sony:
       model: 'Xperia 10 Dual'
     - regex: '(?:Sony(?:Ericsson)?)?(?:J(?:9110|81[17]0)|SOV40|SO-03L|802SO)'
       model: 'Xperia 1'
-    - regex: '(?:Sony(?:Ericsson)?)?(?:SOG01|SO-51A|XQ-AT42|XQ-AT51)(?:[);/ ]|$)'
+    - regex: '(?:Sony(?:Ericsson)?)?(?:SOG01|SO-51A|XQ-AT42|XQ-AT51|SO51Aa)(?:[);/ ]|$)'
       model: 'Xperia 1 II'
+    - regex: '(?:Sony(?:Ericsson)?)?(?:SO-51B|SOG03)(?:[);/ ]|$)'
+      model: 'Xperia 1 III'
     - regex: '(?:Sony(?:Ericsson)?)?LT22i|Xperia P'
       model: 'Xperia P'
     - regex: '(?:Sony(?:Ericsson)?)?LT25i|Xperia V'
@@ -5593,7 +5597,7 @@ Sony:
       model: 'Xperia 5 Dual'
     - regex: '(?:Sony(?:Ericsson)?)?(?:J82[17]0|SO-01M|SOV41|901SO)'
       model: 'Xperia 5'
-    - regex: '(?:Sony(?:Ericsson)?)?(?:SOG02|A002SO|XQ-AS[567]2|SO-52A)'
+    - regex: '(?:Sony(?:Ericsson)?)?(?:SOG02|A002SO|XQ-AS[4567]2|SO-52A)'
       model: 'Xperia 5 II'
     - regex: '(?:Sony(?:Ericsson)?)?(?:SOV42|902SO)'
       model: 'Xperia 8'
@@ -5876,6 +5880,9 @@ Sony:
       brand: 'Sony Ericsson'
     - regex: 'portalmmm/2.0 K([a-z0-9]+)'
       model: 'K$1'
+      brand: 'Sony Ericsson'
+    - regex: 'SonyEricsson ?IS11S'
+      model: 'arco IS11S'
       brand: 'Sony Ericsson'
     - regex: 'Sony ?Ericsson?([^/;]*) Build'
       model: '$1'
@@ -6241,7 +6248,7 @@ FNB:
 
 # Fujitsu
 Fujitsu:
-  regex: '(?:F-01[FHJKLM]|F-02[EFGHLK]|F-03[DEFGKHL]|F-04[EGFHKJ]|F-05[DEFJG]|F-06[EF]|F-07[DE]|F-08D|F-09[DE]|F-10D|F-[45]1A|F-[45]2A|F-11D|F-12C|M532|FARTM933KZ|901FJ|arrows(?:RX|M03|M0[45](?:-PREMIUM)?)|801FJ|FJL2[12])(?:[);/ ]|$)'
+  regex: '(?:F-01[FHJKLM]|F-02[EFGHLK]|F-03[DEFGKHL]|F-04[EGFHKJ]|F-05[DEFJG]|F-06[EF]|F-07[DE]|F-08D|F-09[DE]|F-10D|F-[45]1A|F-41B|F-[45]2A|F-11D|F-12C|M532|FARTM933KZ|901FJ|arrows(?:RX|M03|M0[45](?:-PREMIUM)?)|801FJ|FJL2[12])(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     - regex: 'F-51A(?:[);/ ]|$)'
@@ -6298,6 +6305,8 @@ Fujitsu:
       model: 'Arrows Be 3 F-02L'
     - regex: 'F-41A(?:[);/ ]|$)'
       model: 'Arrows Be 4 F-41A'
+    - regex: 'F-41B(?:[);/ ]|$)'
+      model: 'Arrows Be 4 Plus F-41B'
     - regex: 'F-06E(?:[);/ ]|$)'
       model: 'Arrows NX F-06E'
     - regex: 'F-07D(?:[);/ ]|$)'
@@ -9327,7 +9336,7 @@ LCT:
 
 # Leagoo
 Leagoo:
-  regex: '(?:MY)?LEAGOO[ _-]?|(?:Shark 5000|M5 EDGE|KIICAA (POWER|MIX)|Leapad[ _](?:X|7s)|Elite [15]|Venture 1|Z10-E|M9 Pro|Power 5|Power 2(?: Pro)?)(?:[);/ ]|$)'
+  regex: '(?:MY)?LEAGOO[ _-]?|(?:Shark 5000|M5 EDGE|KIICAA (POWER|MIX)|Leapad[ _](?:X|7s)|Alfa 1|Elite [15]|Venture 1|Z10-E|M9 Pro|Power 5|Power 2(?: Pro)?)(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     - regex: '(?:LEAGOO[- _])?M([89])[_-]?Pro(?:[);/ ]|$)'
@@ -9352,6 +9361,8 @@ Leagoo:
       model: 'Power $1'
     - regex: 'Venture 1(?:[);/ ]|$)'
       model: 'Venture 1'
+    - regex: 'Alfa 1(?:[);/ ]|$)'
+      model: 'Alfa 1'
     - regex: '(?:LEAGOO[- _])?(Z10-E|M6)(?:[);/ ]|$)'
       model: '$1'
     - regex: '(?:My)?Leagoo[- _](E4)(?:[);/ ]|$)'
@@ -11555,6 +11566,8 @@ Motorola:
       model: 'Moto G Stylus'
     - regex: 'moto g power'
       model: 'Moto G Power'
+    - regex: 'moto g pro'
+      model: 'Moto G Pro'
     - regex: 'moto g\(([0-9])\) power lite'
       model: 'Moto G$1 Power Lite'
     - regex: 'moto g\(([0-9])\) power'
@@ -12531,7 +12544,7 @@ OnePlus:
 
 # Realme (sub brand Oppo)
 Realme:
-  regex: 'Realme[ _]|(?:RMX(?:19(03|4[1235]|19|9[23]|2[157]|[01379]1|73)|20(?:[025-7]1|[037]2|2[57]|63|7[56]|8[156]|[2-5]0)|21(?:0[13]|17|[12]1|4[24]|5[15]|6[13]|7[036]|8[059]|9[35])|220[012]|18(0[13579]|11|3[13]|2[157]|[45]1|45)|32(?:01|42|[346]1)|30(?:[348]1|9[23]|63|85)|31(?:2[12]|91))|(?:OPPO[ _]?)?CPH1861)(?:[);/ ]|$)'
+  regex: 'Realme[ _]|(?:RMX(?:19(03|4[1235]|19|9[23]|2[157]|[01379]1|73)|20(?:[025-7]1|[037]2|2[57]|63|7[56]|8[156]|[2-5]0)|21(?:0[13]|17|[12]1|4[24]|5[15]|6[13]|7[036]|8[059]|9[35])|220[0125]|18(0[13579]|11|3[13]|2[157]|[45]1|45)|32(?:01|42|[346]1)|30(?:[348]1|9[23]|63|85)|31(?:2[12]|15|91)|3350)|(?:OPPO[ _]?)?CPH1861)(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     - regex: '(?:OPPO[ _]?)?CPH1861(?:[);/ ]|$)'
@@ -12558,6 +12571,8 @@ Realme:
       model: 'Q2 5G'
     - regex: 'RMX2173'
       model: 'Q2 Pro'
+    - regex: 'RMX2205'
+      model: 'Q3 Pro 5G'
     - regex: 'RMX2176(?:[);/ ]|$)'
       model: 'X7 5G'
     - regex: 'RMX2121(?:[);/ ]|$)'
@@ -12584,6 +12599,8 @@ Realme:
       model: '7I'
     - regex: 'RMX2170'
       model: '7 Pro'
+    - regex: 'RMX3115'
+      model: 'X7 Pro Extreme Edition'
     - regex: 'RMX3081'
       model: '8 Pro'
     - regex: 'RMX3085'
@@ -12620,6 +12637,8 @@ Realme:
       model: 'C11 (2021)'
     - regex: 'RMX3031(?:[);/ ]|$)'
       model: 'GT Neo'
+    - regex: 'RMX3350(?:[);/ ]|$)'
+      model: 'GT Neo Flash'
     - regex: 'RMX216[13](?:[);/ ]|$)'
       model: 'Narzo 20 Pro'
     - regex: 'RMX2193(?:[);/ ]|$)'
@@ -12662,7 +12681,7 @@ Realme:
 
 # Oppo (oppo.com)
 OPPO:
-  regex: '(?:OB-)?OPPO[ _]?([a-z0-9]+)|N1T|R8001|OPG01|A00[12]OP|(?:X90[07][0679]|U70[57]T?|X909T?|R(?:10[01]1|2001|201[07]|6007|7005|7007|80[13579]|81[13579]|82[01379]|83[013]|800[067]|8015|810[679]|811[13]|820[057])[KLSTW]?|N520[79]|N5117|A33f|A33fw|A37fw?|PAAM00|PAAT00|PAC[TM]00|R7kf|R7plusf|R7Plusm|A1601|CPH[0-9]{4}|CPH19(69|79|23|1[179])|PB(A[TM]00|CT10|BT30|CM[13]0|[FD]M00)|P(E[RFHG]M\d{2}|E[GH]T\d{2}|DAM10|ADM00|AF[TM]00|ADT00|AHM00|BBM[03]0|BBT00|BDT00|BFT00|[CB]E[MT]00|CA[MT]00|C[CDG]M00|CA[MT]10|[CD]PM00|CRM00|CDT00|CD[TM]10|CHM[013]0|CKM[08]0|CLM[15]0|DEM[13]0|DHM00|D[RK][TM]00|DPT00|DB[TM]00|DCM00|[CD]NM00|DVM00|DY[TM][12]0|DNT00|EA[TM]00|CRT01|EDM00)|PEG[MT]10|PEM[MT][02]0|PDS[TM]00|PEC[MT]30|PE[EX]M00)(?:[);/ ]|$)'
+  regex: '(?:OB-)?OPPO[ _]?([a-z0-9]+)|N1T|R8001|A101OP|OPG01|A00[12]OP|(?:OPG02|X90[07][0679]|U70[57]T?|X909T?|R(?:10[01]1|2001|201[07]|6007|7005|7007|80[13579]|81[13579]|82[01379]|83[013]|800[067]|8015|810[679]|811[13]|820[057])[KLSTW]?|N520[79]|N5117|A33f|A33fw|A37fw?|PAAM00|PAAT00|PAC[TM]00|R7kf|R7plusf|R7Plusm|A1601|CPH[0-9]{4}|CPH19(69|79|23|1[179])|PB(A[TM]00|CT10|BT30|CM[13]0|[FD]M00)|P(E[RFHG]M\d{2}|E[GH]T\d{2}|DAM10|ADM00|AF[TM]00|ADT00|AHM00|BBM[03]0|BBT00|BDT00|BFT00|[CB]E[MT]00|CA[MT]00|C[CDG]M00|CA[MT]10|[CD]PM00|CRM00|CDT00|CD[TM]10|CHM[013]0|CKM[08]0|CLM[15]0|DEM[13]0|DHM00|D[RK][TM]00|DPT00|DB[TM]00|DCM00|[CD]NM00|DVM00|DY[TM][12]0|DNT00|EA[TM]00|CRT01|EDM00)|PEG[MT]10|PEM[MT][02]0|PDS[TM]00|PEC[MT]30|PE[EX]M00)(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     - regex: 'PCHM10(?:[);/ ]|$)'
@@ -12707,7 +12726,7 @@ OPPO:
       model: 'A53'
     - regex: 'CPH2135(?:[);/ ]|$)'
       model: 'A53s'
-    - regex: 'CPH2195(?:[);/ ]|$)'
+    - regex: '(?:CPH2195|OPG02|CPH2303)(?:[);/ ]|$)'
       model: 'A54 5G'
     - regex: 'CPH2239(?:[);/ ]|$)'
       model: 'A54'
@@ -12723,7 +12742,7 @@ OPPO:
       model: 'A71'
     - regex: '(?:OPPO[ _]?)?(?:PDY[TM]20|CPH2067)(?:[);/ ]|$)'
       model: 'A72'
-    - regex: 'CPH2161(?:[);/ ]|$)'
+    - regex: 'CPH(?:2161|2099)(?:[);/ ]|$)'
       model: 'A73 5G'
     - regex: 'CPH2219(?:[);/ ]|$)'
       model: 'A74'
@@ -12943,6 +12962,8 @@ OPPO:
       model: 'Reno 4F'
     - regex: 'CPH2159(?:[);/ ]|$)'
       model: 'Reno 5'
+    - regex: '(?:CPH2199|A101OP)(?:[);/ ]|$)'
+      model: 'Reno 5A'
     - regex: 'CPH2205(?:[);/ ]|$)'
       model: 'Reno 5 Lite'
     - regex: '(?:PEG[MT]00|CPH2145)(?:[);/ ]|$)'
@@ -13635,7 +13656,7 @@ Soundmax:
 
 # Samsung
 Samsung:
-  regex: 'SAMSUNG(?! ?Browser)|lineage_j5y17lte|Maple (?!III)|SC-(?:01[FGHKLM]|02[CGHJKLM]|03[JKL]|04[EJL]|05[GL]|(?:4[12]|5[1234])A)|N[57]100|N5110|N9100|S(?:CH|GH|PH|EC|AM|HV|HW|M)-|SMART-TV|GT-|(?<!GOG|GOG )Galaxy|(?:portalmmm|o2imode)/2\.0 [SZ]|sam[rua]|vollo Vi86(?:[);/ ]|$)|(?:OTV-)?SMT-E5015|ISW11SC|40[34]SC|SC(?:V3[1-9]|V4[0-9]|51Aa|T21|G0[1-9]|G10|L2[234])(?:-[uj])?(?:[);/ ]|$)'
+  regex: 'SAMSUNG(?! ?Browser)|lineage_j5y17lte|Maple (?!III)|SC-(?:01[FGHKLM]|02[CGHJKLM]|03[JKLE]|04[EFJL]|05[GL]|(?:4[12]|5[1234])A|5[123]B)|N[57]100|N5110|N9100|S(?:CH|GH|PH|EC|AM|HV|HW|M)-|SMART-TV|GT-|(?<!GOG|GOG )Galaxy|(?:portalmmm|o2imode)/2\.0 [SZ]|sam[rua]|vollo Vi86(?:[);/ ]|$)|(?:OTV-)?SMT-E5015|ISW11SC|40[34]SC|SC(?:V3[1-9]|V4[0-9]|51Aa|T21|G0[1-9]|G10|L2[234])(?:-[uj])?(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     # explicit tv models
@@ -14149,7 +14170,7 @@ Samsung:
       model: 'Galaxy S4 Value Edition'
     - regex: '(?:SAMSUNG-)?GT-I9295'
       model: 'Galaxy S4 ACTIVE'
-    - regex: '(?:SAMSUNG-)?(?:GT-I9300|SCH-(?:I535|I939|L710))'
+    - regex: '(?:SAMSUNG-)?(?:GT-I9300|SCH-(?:I535|I939|L710))|SC-03E'
       model: 'Galaxy S III'
     - regex: '(?:SAMSUNG-)?(?:GT-I9305|SCH-R530)'
       model: 'Galaxy S III LTE'
@@ -14263,7 +14284,7 @@ Samsung:
       model: 'Galaxy S5 Dual-SIM'
     - regex: '(?:SAMSUNG-)?SM-G900FD'
       model: 'Galaxy S5 Duos'
-    - regex: '(?:SAMSUNG-)?SM-(?:G900|G906[KLS]|S902L|S903VL)|Galaxy-S5|SCL23'
+    - regex: '(?:SAMSUNG-)?SM-(?:G900|G906[KLS]|S902L|S903VL)|Galaxy-S5|SCL23|SC-04F'
       model: 'Galaxy S5'
     - regex: '(?:SAMSUNG-)?SM-G901F'
       model: 'Galaxy S5 LTE+'
@@ -14325,7 +14346,9 @@ Samsung:
       model: 'Galaxy S20+ 5G'
     - regex: '(?:SAMSUNG-)?SM-G991(?:U1|[0BNW])|SCG09'
       model: 'Galaxy S21 5G'
-    - regex: '(?:SAMSUNG-)?SM-G998(?:U1|[0BNUW])'
+    - regex: '(?:SAMSUNG-)?SC-51B'
+      model: 'Galaxy S21 5G Olympic Games Edition'
+    - regex: '(?:SAMSUNG-)?(?:SM-G998(?:U1|[0BNUW])|SC-52B)'
       model: 'Galaxy S21 Ultra 5G'
     - regex: '(?:SAMSUNG-)?SM-G996(?:U1|[0BNWU])|SCG10'
       model: 'Galaxy S21+ 5G'
@@ -14377,6 +14400,8 @@ Samsung:
       model: 'Galaxy A5 (2017)'
     - regex: '(?:SAMSUNG-)?SM-A525F'
       model: 'Galaxy A52'
+    - regex: '(?:SAMSUNG-)?SC-53B'
+      model: 'Galaxy A52 5G'
     - regex: '(?:SAMSUNG-)?SM-A600(?:AZ|FN|GN|T1|[AFGNPTUX])'
       model: 'Galaxy A6'
     - regex: '(?:SAMSUNG-)?SM-A605(?:[FG]N|[08FGX])'
@@ -15829,7 +15854,7 @@ Spice:
 
 # Sharp (jp.sharp)
 Sharp:
-  regex: 'SHARP|SBM|SH-?[0-9]+[a-z]?(?:[);/ ]|$)|AQUOS|(?:SH-M0[14-9]|SH-M1[1-7](?:-y)?|S[357]-SH|SH-[MZ](10|01)|SH-[CL]02|SH-RM(?:1[125]|02)|[34]04SH|401SH|[45]02SH|306SH|[36]05SH|70[1246]SH|80[138]SH|90[1678]SH|50[3679]SH|SHL2[25]|SHV4[0-8]|SHV3[1-9](?:[-_]u)?|FS80(?:1[08]|32|28|0[29])|TG-L900S|NP601SH|403SH|603SH|SHF3[1-4]|SHV4[035][-_]u|SW001SH|SHG0[123]|X4-SH|A002SH|SH-A01|DM-01[JH]|SH-D01|SH-01FDQ|A001SH|606SH|FS801[56]|d-41A|NP80[567]SH|NP501SH|A00[34]SH|IS05|SH-H01)(?:[);/ ]|$)'
+  regex: 'SHARP|SBM|SH-?[0-9]+[a-z]?(?:[);/ ]|$)|AQUOS|(?:SH-M0[14-9]|SH-M1[1-7](?:-y)?|S[357]-SH|SH-[MZ](10|01)|SH-[CL]02|SH-RM(?:1[125]|02)|[34]04SH|401SH|[45]02SH|306SH|[36]05SH|70[1246]SH|80[138]SH|90[1678]SH|50[3679]SH|SHL2[25]|SHV4[0-8]|SHV3[1-9](?:[-_]u)?|FS80(?:1[08]|32|28|0[29])|TG-L900S|NP601SH|403SH|603SH|SHF3[1-4]|SHV4[035][-_]u|SW001SH|SHG0[123]|X4-SH|A002SH|SH-A01|DM-01[JH]|SH-D01|SH-01FDQ|A[01]01SH|606SH|FS801[56]|d-41A|NP80[567]SH|NP501SH|A00[34]SH|IS05|SH-(?:53A|51B|H01))(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     # explicit smartphone models
@@ -15863,7 +15888,7 @@ Sharp:
       model: 'Aquos Sense 4 Basic'
     - regex: 'SH-41A(?:[);/ ]|$)'
       model: 'Aquos Sense 4'
-    - regex: '(?:SHG03|A004SH|SH-M17)(?:[);/ ]|$)'
+    - regex: '(?:SHG03|A004SH|SH-M17|SH-53A)(?:[);/ ]|$)'
       model: 'Aquos Sense 5G'
     - regex: 'SH-D01(?:[);/ ]|$)'
       model: 'Aquos D10'
@@ -15873,7 +15898,7 @@ Sharp:
       model: 'Aquos Zeta'
     - regex: '(?:SH-[MZ]10|801SH)(?:[);/ ]|$)'
       model: 'Aquos Zero'
-    - regex: '(?:SH-M13|906SH)(?:[);/ ]|$)'
+    - regex: '(?:SH-M13|906SH|SH-01M)(?:[);/ ]|$)'
       model: 'Aquos Zero 2'
     - regex: '(?:SHG02|A002SH)(?:[);/ ]|$)'
       model: 'Aquos Zero 5G Basic'
@@ -15951,6 +15976,8 @@ Sharp:
       model: 'Aquos S4 Lite'
     - regex: 'SH-51A(?:[);/ ]|$)'
       model: 'Aquos R5G'
+    - regex: '(?:SH-51B|A101SH)(?:[);/ ]|$)'
+      model: 'Aquos R6'
     - regex: 'SHV3[57](?:_u)?(?:[);/ ]|$)'
       model: 'Aquos U'
     - regex: 'TG-L900S(?:[);/ ]|$)'
@@ -16286,7 +16313,7 @@ T-Mobile:
 
 # Teclast (teclast.com)
 Teclast:
-  regex: 'Teclast|TLA002|TLA016|X98 Air III|M20_4G|X98 Air II\(HG5N\)|Tbook|X80 Power\(B2N4\)|(?:T30|P80[XH]|P20HD|P10[_ ]HD|M40|P10S)_(?:ROW|EEA)|T10\(E3C6\)|P10S\(N4H5\)|98\(M1E[45789]\)|98\(M3E3\)|X10 \(M1D3\)'
+  regex: 'Teclast|TLA002|TLA016|X98 Air III|M20_4G|X98 Air II\(HG5N\)|Tbook|X80 Power\(B2N4\)|(?:T30|P80[XH]|P20HD|P10[_ ]HD|M40|P10S|M30_Pro)_(?:ROW|EEA)|T10\(E3C6\)|P10S\(N4H5\)|98\(M1E[45789]\)|98\(M3E3\)|X10 \(M1D3\)'
   device: 'tablet'
   models:
     - regex: 'Tbook[_ -]([^;/]+) Build'
@@ -16301,6 +16328,8 @@ Teclast:
       model: 'P20HD'
     - regex: 'P10[_ ]HD_(?:ROW|EEA)'
       model: 'P10HD'
+    - regex: 'M30_Pro[_ ](?:ROW|EEA)'
+      model: 'M30 Pro'
     - regex: 'M20_4G'
       model: 'M20 4G'
     - regex: 'TLA002'
@@ -16507,6 +16536,8 @@ Tecno Mobile:
     - regex: 'TECNO[ _]LE7n?(?:[);/ ]|$)'
       device: 'phablet'
       model: 'Pova 2'
+    - regex: 'Tecno (F2) ?LTE'
+      model: '$1 LTE'
     - regex: 'Tecno ([^;/]+) Build'
       model: '$1'
     - regex: 'Tecno[ _-]?([a-z0-9_\-]+)'
@@ -18041,7 +18072,7 @@ POCO:
 
 # Xiaomi
 Xiaomi:
-  regex: 'Xiaomi(?!/(?:Miui|Mint[ ])Browser)|Mi9 Pro 5G|(?:MI [a-z0-9]+|Mi-4c|MI-One[ _]?[a-z0-9]+|MIX(?: 2S?)?)(?:[);/ ]|$)|HM (?:[^/;]+) (?:Build|MIUI)|(?:2014501|2014011|201481[12378]|201302[23]|2013061) Build|Redmi|POCOPHONE|(?:SHARK )?(KLE|MBU)-[AH]0|SK[RW]-[AH]0|PRS-H0|POCO F1|DLT-[AH]0|MIBOX[234]([_ ]PRO)?|MiTV4[CSX]?|MiTV-(MSSP[01]|AXSO0|AESP0)|AWM-A0|MI CC 9 Meitu Edition|MiBOX1S|MiTV4A|M2006J10C|M2006C3(?:L[IGC]|LVG|MN?G|MT)|M2007J1(?:7[CGI]|SC)|M2002J9[EG]|HM2014819|WT88047|M2004J(?:7[AB]|19)C|M2012K11(?:[CG]|AC)|M2011K2[CG]|M2006C3[ML]II|M2003J15SC|M2007J3S[ICYGP]|M2007J22[CG]|M2103K19[GY]|M2101K(?:[79]AG|7AI|7B[GI]|6[GIRP]|7BNY|9[GC])|M2010J19S[CGYI]|M1908C3JGG|M2102(?:K1[CG]|J2SC)|HM NOTE 1(?:LTE|W)|MI[_ ]PLAY|XIG01|Qin 1s\+|MI_(NOTE_Pro|5X|4i|(?:A2|8)_Lite)|A001XM|lancelot'
+  regex: 'Xiaomi(?!/(?:Miui|Mint[ ])Browser)|Mi9 Pro 5G|(?:MI [a-z0-9]+|Mi-4c|MI-One[ _]?[a-z0-9]+|MIX(?: 2S?)?)(?:[);/ ]|$)|HM (?:[^/;]+) (?:Build|MIUI)|(?:2014501|2014011|201481[12378]|201302[23]|2013061) Build|Redmi|POCOPHONE|(?:SHARK )?(KLE|MBU)-[AH]0|SK[RW]-[AH]0|PRS-H0|POCO F1|DLT-[AH]0|MIBOX[234]([_ ]PRO)?|MiTV4[CSX]?|MiTV-(MSSP[01]|AXSO0|AESP0)|AWM-A0|MI CC 9 Meitu Edition|MiBOX1S|MiTV4A|M2006J10C|M2006C3(?:L[IGC]|LVG|MN?G|MT)|M2007J1(?:7[CGI]|SC)|M2002J9[EG]|HM2014819|WT88047|M2004J(?:7[AB]|19)C|M2012K11(?:[CG]|AC)|M2011K2[CG]|M2006C3[ML]II|M2003J15SC|M2007J3S[ICYGP]|M2007J22[CG]|M2103K19[GY]|M2101K(?:[79]AG|7AI|7B[GI]|6[GIRP]|7BNY|9[GCR])|M2010J19S[CGYI]|M1908C3JGG|M2102(?:K1[CG]|J2SC)|HM NOTE 1(?:LTE|W)|MI[_ ]PLAY|XIG01|Qin 1s\+|MI_(NOTE_Pro|5X|4i|(?:A2|8)_Lite)|A001XM|lancelot'
   device: 'smartphone'
   models:
     # specific smartphone models
@@ -18105,7 +18136,7 @@ Xiaomi:
       model: 'Mi 11i'
     - regex: 'M2101K9AG(?:[);/ ]|$)'
       model: 'Mi 11 Lite'
-    - regex: 'M2101K9[GC](?:[);/ ]|$)'
+    - regex: 'M2101K9[GCR](?:[);/ ]|$)'
       model: 'Mi 11 Lite 5G'
     - regex: 'M2102K1[CG](?:[);/ ]|$)'
       model: 'Mi 11 Ultra'
@@ -21951,15 +21982,17 @@ VVETIME:
   device: 'smartphone'
   model: 'V1'
 
-# A1
+# A1 (www.a1.by)
 A1:
-  regex: 'A1 (?:Alpha|Alpha 20\+)(?:[);/ ]|$)'
+  regex: '(?:A1 (?:Alpha|Alpha 20\+)|Alpha 20)(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     - regex: 'A1 Alpha 20\+'
-      model: 'Alpha 20 Plus'
+      model: 'Alpha 20 Plus'  # ZTE Blade V2020
     - regex: 'A1 Alpha'
       model: 'Alpha'
+    - regex: 'Alpha 20'
+      model: 'Alpha 20'
 
 # Swisstone
 Swisstone:
@@ -22281,7 +22314,7 @@ iSWAG:
 
 # Reeder (reeder.com.tr)
 Reeder:
-  regex: '(?:reeder[_ ](?:3G_Tablet|A7iC|A[78]i[_ ]Quad|A8i Q2|M8 Plus|[TM]8|M10 Plus|P11SE)|P12Curve)(?:[);/ ]|$)'
+  regex: '(?:reeder[_ ](?:3G_Tablet|A7iC|A[78]i[_ ]Quad|A8i Q2|M8 Plus|[TM]8|M10 Plus|P11SE)|P12Curve|P13_Blue_Maks)(?:[);/ ]|$)'
   device: 'tablet'
   models:
     - regex: 'reeder[_ ](3G_Tablet|A7iC|A[78]i[_ ]Quad|A8i Q2|M8 Plus|[TM]8|M10 Plus|P11SE)(?:[);/ ]|$)'
@@ -22289,6 +22322,9 @@ Reeder:
     - regex: 'P12Curve'
       device: 'smartphone'
       model: 'P12 Curve'
+    - regex: 'P13_Blue_Maks'
+      device: 'smartphone'
+      model: 'P13 Blue Maks'
 
 
 # ELARI (elari.net)

--- a/tests/fixtures/devices/mobile_apps.yml
+++ b/tests/fixtures/devices/mobile_apps.yml
@@ -1151,3 +1151,19 @@
     model: ""
   os_family: iOS
   browser_family: Unknown
+-
+  user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16C101 LightSpeed [FBAN/MessengerLiteForiOS;FBAV/326.1.0.37.112;FBBV/311948716;FBDV/iPhone8,1;FBMD/iPhone;FBSN/iOS;FBSV/12.1.2;FBSS/2;FBCR/;FBID/phone'
+  os:
+    name: iOS
+    version: 12.1.2
+    platform: ""
+  client:
+    type: mobile app
+    name: Facebook Messenger Lite
+    version: 326.1.0.37.112
+  device:
+    type: smartphone
+    brand: Apple
+    model: iPhone 6s
+  os_family: iOS
+  browser_family: Unknown

--- a/tests/fixtures/devices/phablet.yml
+++ b/tests/fixtures/devices/phablet.yml
@@ -6896,3 +6896,21 @@
     model: M10 Ultra
   os_family: Android
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; SM-N950N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: phablet
+    brand: Samsung
+    model: Galaxy Note 8
+  os_family: Android
+  browser_family: Chrome

--- a/tests/fixtures/devices/smartphone-25.yml
+++ b/tests/fixtures/devices/smartphone-25.yml
@@ -9467,3 +9467,165 @@
     model: R11 Plus
   os_family: Android
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Alpha 20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.120
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: A1
+    model: Alpha 20
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; BKL-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.80 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.80
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Huawei
+    model: Honor V10
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; BLA-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.164
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Huawei
+    model: Mate 10 Pro
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; Core-X4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.120
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Crosscall
+    model: Core-X4
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; RMX3350) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.120
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Realme
+    model: GT Neo Flash
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; RMX3115) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Mobile Safari/537.36 OPR/64.1.3282.59829
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Opera Mobile
+    version: 64.1.3282.59829
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Realme
+    model: X7 Pro Extreme Edition
+  os_family: Android
+  browser_family: Opera
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; RMX2205) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.164
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Realme
+    model: Q3 Pro 5G
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; SM-A015F Build/RP1A.200720.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.210 Mobile Safari/537.36 OPX/1.0
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 90.0.4430.210
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Samsung
+    model: Galaxy A01
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; TECNO F2LTE Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/91.0.4472.120 Mobile Safari/537.36 OPR/57.0.2254.58007
+  os:
+    name: Android
+    version: 8.1.0
+    platform: ""
+  client:
+    type: browser
+    name: Opera Mobile
+    version: 57.0.2254.58007
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Tecno Mobile
+    model: F2 LTE
+  os_family: Android
+  browser_family: Opera

--- a/tests/fixtures/devices/smartphone-26.yml
+++ b/tests/fixtures/devices/smartphone-26.yml
@@ -1,0 +1,739 @@
+---
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; P13_Blue_Maks) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.77
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Reeder
+    model: P13 Blue Maks
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 5.1; Alfa 1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "5.1"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 46.0.2490.76
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Leagoo
+    model: Alfa 1
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; SO-41B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Sony
+    model: Xperia Ace II
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; SO-52B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.131
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Sony
+    model: Xperia 10 III
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; A102SO Build/62.0.D.1.87; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Webview
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Sony
+    model: Xperia 10 III
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; CPH2099) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: OPPO
+    model: A73 5G
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; OPG02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: OPPO
+    model: A54 5G
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; ASUS_I005DC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Asus
+    model: ROG Phone 5
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; M2101K9R) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Xiaomi
+    model: Mi 11 Lite 5G
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; CPH2199) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: OPPO
+    model: Reno 5A
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; SNE-LX2 Build/HUAWEISNE-LX2; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Webview
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Huawei
+    model: Mate 20 Lite
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; CPH2303) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: OPPO
+    model: A54 5G
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; SH-51B Build/S5765; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Webview
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Sharp
+    model: Aquos R6
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; SC-51B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Samsung
+    model: Galaxy S21 5G Olympic Games Edition
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.1.1; F-05J Build/V26R045A; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: 7.1.1
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Webview
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Fujitsu
+    model: Arrows Be F-05J
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; F-41B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Fujitsu
+    model: Arrows Be 4 Plus F-41B
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; SH-01M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Sharp
+    model: Aquos Zero 2
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; moto g(8) plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Motorola
+    model: Moto G8 Plus
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; 201HW Build/HuaweiU9201L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+  os:
+    name: Android
+    version: 4.0.4
+    platform: ""
+  client:
+    type: browser
+    name: Android Browser
+    version: ""
+    engine: WebKit
+    engine_version: "534.30"
+  device:
+    type: smartphone
+    brand: Huawei
+    model: U9201L
+  os_family: Android
+  browser_family: Android Browser
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; SOG04) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.120
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Sony
+    model: Xperia 10 III
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; SH-53A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.131
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Sharp
+    model: Aquos Sense 5G
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; SM-G973C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Samsung
+    model: Galaxy S10
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; SO-51B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Sony
+    model: Xperia 1 III
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; SC-52B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.101 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 87.0.4280.101
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Samsung
+    model: Galaxy S21 Ultra 5G
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; moto g(30)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Motorola
+    model: Moto G30
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; moto g pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Motorola
+    model: Moto G Pro
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; SOG03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Sony
+    model: Xperia 1 III
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; A101OP Build/RKQ1.201217.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Webview
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: OPPO
+    model: Reno 5A
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; A101SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Sharp
+    model: Aquos R6
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; XQ-AS42 Build/58.1.A.5.330; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Webview
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Sony
+    model: Xperia 5 II
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; SC-53B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Samsung
+    model: Galaxy A52 5G
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; ja-jp; SonyEricssonIS11S Build/4.0.1.B.0.118) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+  os:
+    name: Android
+    version: 2.3.4
+    platform: ""
+  client:
+    type: browser
+    name: Android Browser
+    version: ""
+    engine: WebKit
+    engine_version: "533.1"
+  device:
+    type: smartphone
+    brand: Sony Ericsson
+    model: arco IS11S
+  os_family: Android
+  browser_family: Android Browser
+-
+  user_agent: Mozilla/5.0 (Linux; Android 9; F-01K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Fujitsu
+    model: Arrows NX F-01K
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 6.0.1; F-02H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Mobile Safari/537.36
+  os:
+    name: Android
+    version: 6.0.1
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 91.0.4472.101
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Fujitsu
+    model: Arrows NX F-02H
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SHV37 Build/SB081) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
+  os:
+    name: Android
+    version: 8.0.0
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 69.0.3497.100
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Sharp
+    model: Aquos U
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SC-04F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.3613
+  os:
+    name: Android
+    version: 6.0.1
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Samsung
+    model: Galaxy S5
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 4.1.1; SC-03E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
+  os:
+    name: Android
+    version: 4.1.1
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 71.0.3578.99
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Samsung
+    model: Galaxy S III
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 11; SO51Aa) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "11"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Sony
+    model: Xperia 1 II
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; STK-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.105 Mobile Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 89.0.4389.105
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Huawei
+    model: Y9 Prime (2019)
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Moto G (5) Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: 8.1.0
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Motorola
+    model: Moto G5 Plus
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 5.0.2; F-05F Build/V15R33E; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/92.0.4515.159 Mobile Safari/537.36
+  os:
+    name: Android
+    version: 5.0.2
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Webview
+    version: 92.0.4515.159
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: Fujitsu
+    model: Arrows NX F-05F
+  os_family: Android
+  browser_family: Chrome

--- a/tests/fixtures/devices/tablet-6.yml
+++ b/tests/fixtures/devices/tablet-6.yml
@@ -612,3 +612,21 @@
     model: Libra 4 3G
   os_family: Android
   browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 10; M30_Pro_ROW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Safari/537.36
+  os:
+    name: Android
+    version: "10"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome
+    version: 91.0.4472.120
+    engine: Blink
+    engine_version: ""
+  device:
+    type: tablet
+    brand: Teclast
+    model: M30 Pro
+  os_family: Android
+  browser_family: Chrome


### PR DESCRIPTION
* feat(device) detect brand A1 model: Alpha 20
feat(device) detect brand Huawei models: Honor V10 (BKL-AL00), Mate 10 Pro (BLA-AL00)
feat(device) detect brand Crosscall model: Core-X4
feat(device) detect brand Samsung model: Galaxy A01 (SM-A015F)
feat(device) detect brand Tecno Mobile model: F2 LTE
feat(device) detect brand Teclast model: M30 Pro
feat(device) detect brand Realme models: GT Neo Flash (RMX3350), X7 Pro Extreme Edition (RMX3115), Q3 Pro 5G (RMX2205)

* feat(device) test brand Apple model: iPhone 6s (iPhone8,1)
feat(device) test brand Huawei model: Mate 20 Lite (SNE-LX2)
feat(device) detect brand Reeder model: P13 Blue Maks
feat(device) detect brand Leagoo model: Alfa 1
feat(device) detect brand OPPO models: A73 5G (CPH2099), A54 5G (OPG02, CPH2303), Reno 5A (CPH2199)
feat(device) detect brand Sony models: Xperia Ace II (SO-41B), Xperia 10 III (SO-52B, A102SO)
feat(device) detect brand Asus model: ROG Phone 5 (ASUS_I005DC)
feat(device) detect brand Xiaomi model: Mi 11 Lite 5G (M2101K9R)
feat(device) detect brand Sharp model: Aquos R6 (SH-51B)
feat(device) detect brand Samsung model: Galaxy S21 5G Olympic Games Edition (SC-51B)

* feat(device) test brand Samsung models: Galaxy Note 8 (SM-N950N), Galaxy S10 (SM-G973C)
feat(device) test brand Fujitsu model: Arrows Be F-05J
feat(device) test brand Motorola model: Moto G8 Plus
feat(device) test brand Huawei model: U9201L
feat(device) detect brand Fujitsu model: Arrows Be 4 Plus F-41B
feat(device) detect brand Sharp models: Aquos Zero 2 (SH-01M), Aquos Sense 5G (SH-53A)
feat(device) detect brand Sony model: Xperia 10 III (SOG04)

* feat(device) test brand Motorola model: Moto G30
feat(device) detect brand Motorola model: Moto G Pro
feat(device) detect brand OPPO model: Reno 5A (A101OP)
feat(device) detect brand Sharp model: Aquos R6 (A101SH)
feat(device) detect brand Sony models: Xperia 1 III (SO-51B, SOG03), Xperia 5 II (XQ-AS42)
feat(device) detect brand Samsung model: Galaxy S21 Ultra 5G (SC-52B)

* feat(device) test brand Fujitsu models: Arrows NX F-01K, Arrows NX F-02H
feat(device) test brand Sharp model: Aquos U (SHV37)

feat(device) detect brand Sony Ericsson model: arco IS11S
feat(device) detect brand Samsung models: Galaxy A52 5G (SC-53B), Galaxy S5 (SC-04F)

* feat(device) test brand Huawei model: Y9 Prime (2019) (STK-L22)
feat(device) test brand Motorola model: Moto G5 Plus
feat(device) test brand Fujitsu model: Arrows NX F-05F

feat(device) detect brand Sony model: Xperia 1 II (SO51Aa)
feat(device) detect brand Samsung models: Galaxy S III (SC-03E)