### PR TITLE
Fix null pointer exception in Linux client hints detection

### DIFF
--- a/parser/os-abstract-parser.js
+++ b/parser/os-abstract-parser.js
@@ -312,7 +312,7 @@ class OsAbstractParser extends ParserAbstract {
       }
 
       // Meta Horizon is reported as Linux in client hints
-      if ('GNU/Linux' === name && 'Meta Horizon' === data.name) {
+      if (data && 'GNU/Linux' === name && 'Meta Horizon' === data.name) {
         name = data.name;
         short = data.short_name;
       }


### PR DESCRIPTION
Thanks for the great package!

- Add null check for data object in Meta Horizon detection logic
- Prevents TypeError when user-agent cannot be parsed but client hints contain 'sec-ch-ua-platform': 'Linux'
- Follows same pattern as other client hints checks in the same function
- Fixes issue where Meta crawler and empty UA strings would crash with Linux platform hints

Fixes [#230](https://github.com/sanchezzzhak/node-device-detector/issues/230): TypeError: Cannot read properties of null (reading 'name')